### PR TITLE
allow specifying target .md file for convert-twiki

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update -y \
 RUN pip install mkdocs MarkdownHighlight pygments
 
 COPY convert-twiki /usr/local/bin/
+COPY convert-twiki-list /usr/local/bin/
 COPY osg-conversions.py /usr/local/bin/
 
 ENTRYPOINT []

--- a/convert-twiki
+++ b/convert-twiki
@@ -2,11 +2,23 @@
 set -e
 set -o pipefail
 
-TWIKI=$1
-MARKDOWN=$2
+usage () {
+  echo "usage: $(basename "$0") TWIKI-URL [PATH-TO-MARKDOWN.md]"
+  exit 1
+}
 
+[[ $1 = https://twiki.opensciencegrid.org/* ]] || usage
+
+TWIKI=$1
 TITLE=$(basename "$TWIKI")
 ARCHIVE=archive/$TITLE
+
+case $2 in
+    '' ) MARKDOWN=$TITLE.md ;;
+  *.md ) MARKDOWN=$2 ;;
+     * ) echo "PATH-TO-MARKDOWN does not end in .md" >&2
+         usage ;;
+esac
 
 tmo_msg () (
   set +e
@@ -19,7 +31,8 @@ tmo_msg () (
   return $e
 )
 
-curl  "$TWIKI?raw=text" | iconv -f windows-1252 > $ARCHIVE
+mkdir -p "$(dirname "$MARKDOWN")"
+curl -s --show-error "$TWIKI?raw=text" | iconv -f windows-1252 > "$ARCHIVE"
 tmo_msg \
-pandoc -f twiki -t markdown_github $ARCHIVE | osg-conversions.py > $TITLE.md
+pandoc -f twiki -t markdown_github "$ARCHIVE" | osg-conversions.py > "$MARKDOWN"
 

--- a/convert-twiki-list
+++ b/convert-twiki-list
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+
+usage () {
+  echo "usage: $(basename "$0") TWIKI-TO-MD-FILE"
+  echo
+  echo "TWIKI-TO-MD-FILE contains lines of the form:"
+  echo "TWIKI-URL PATH-TO-MARKDOWN.md"
+  echo "as accepted by the convert-twiki script"
+  exit
+}
+
+[[ -r $1 ]] || usage
+
+while read twiki_url md_path; do
+  "$(dirname "$0")"/convert-twiki "$twiki_url" "$md_path" < /dev/null
+done < "$1"
+


### PR DESCRIPTION
also, only show errors for curl.

Also, minimal `convert-twiki-list` wrapper script for converting a list of twiki doc urls to md files.