### PR TITLE
use 60s timeout

### DIFF
--- a/convert-twiki
+++ b/convert-twiki
@@ -22,7 +22,7 @@ esac
 
 tmo_msg () (
   set +e
-  timeout 10 "$@"
+  timeout 60 "$@"
   local e=$?
   if [[ $e -eq 124 ]]; then
     echo "$1 command timed out" >&2


### PR DESCRIPTION
... some pandoc conversions take a bit more than 10s, as it turns out...